### PR TITLE
reduce complexity of onMessage

### DIFF
--- a/PublishedModules/glueckself/MpdClient/MpdClient.install
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.install
@@ -4,7 +4,7 @@
 	"author": "glueckself",
 	"maintainers": ["maxbachmann"],
 	"desc": "Control an MPD server",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.11,
 	"systemRequirements": [],
 	"pipRequirements": ["python-mpd2"],
 	"conditions": {

--- a/PublishedModules/glueckself/MpdClient/MpdClient.py
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.py
@@ -29,8 +29,10 @@ class MpdClient(Module):
 			self._INTENT_NEXT: self.nextIntent,
 			self._INTENT_PREV: self.prevIntent
 		}
+		#TODO volume, playlists, ...
+		#TODO pause music if alice starts a dialogue
 
-		super().__init__(list(self._ACTIONS))
+		super().__init__(list(self._ACTIONS), actionMappings=self._ACTIONS)
 
 		self._host = self.getConfig('mpdHost')
 		self._port = self.getConfig('mpdPort')
@@ -75,25 +77,13 @@ class MpdClient(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		if not self._mpdConnected:
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('notConnected'))
 			return True
-
-		sessionId = session.sessionId
-
-		try:
-			self._ACTIONS[intent](session)
-			return True
-		except KeyError:
-			return False
-		#TODO volume, playlists, ...
-		#TODO pause music if alice starts a dialogue
+		super().onMessage(intent=intent, session=session)
 
 
-	def playIntent(self, session: DialogSession):
+	def playIntent(self, intent: str, session: DialogSession):
 		if self._playbackStatus:
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('alreadyPlaying'))
 		else:
@@ -101,7 +91,7 @@ class MpdClient(Module):
 			self.endDialog(sessionId=session.sessionId)
 	
 
-	def stopIntent(self, session: DialogSession):
+	def stopIntent(self, intent: str, session: DialogSession):
 		# note that _playbackStatus can also be None when disconnected.
 		# while it shouldn't reach this line in that case, better to be on the safe side
 		if not self._playbackStatus:
@@ -111,13 +101,13 @@ class MpdClient(Module):
 			self.endDialog(sessionId=session.sessionId)
 	
 
-	def nextIntent(self, session: DialogSession):
+	def nextIntent(self, intent: str, session: DialogSession):
 		# TODO maybe say the title here if not playing
 		self._mpd.next()
 		self.endDialog(sessionId=session.sessionId)
 	
 
-	def prevIntent(self, session: DialogSession):
+	def prevIntent(self, intent: str, session: DialogSession):
 		# TODO maybe say the title here if not playing
 		self._mpd.previous()
 		self.endDialog(sessionId=session.sessionId)

--- a/PublishedModules/glueckself/MpdClient/MpdClient.py
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.py
@@ -23,7 +23,7 @@ class MpdClient(Module):
 	_INTENT_PREV = Intent('mpdPrev')
 
 	def __init__(self):
-		self._ACTIONS = {
+		self._INTENTS = {
 			self._INTENT_PLAY: self.playIntent,
 			self._INTENT_STOP: self.stopIntent,
 			self._INTENT_NEXT: self.nextIntent,
@@ -32,7 +32,7 @@ class MpdClient(Module):
 		#TODO volume, playlists, ...
 		#TODO pause music if alice starts a dialogue
 
-		super().__init__(list(self._ACTIONS), actionMappings=self._ACTIONS)
+		super().__init__(list(self._INTENTS), actionMappings=self._INTENTS)
 
 		self._host = self.getConfig('mpdHost')
 		self._port = self.getConfig('mpdPort')

--- a/PublishedModules/glueckself/MpdClient/MpdClient.py
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.py
@@ -32,7 +32,7 @@ class MpdClient(Module):
 		#TODO volume, playlists, ...
 		#TODO pause music if alice starts a dialogue
 
-		super().__init__(list(self._INTENTS), actionMappings=self._INTENTS)
+		super().__init__(self._INTENTS)
 
 		self._host = self.getConfig('mpdHost')
 		self._port = self.getConfig('mpdPort')

--- a/PublishedModules/glueckself/MpdClient/README.md
+++ b/PublishedModules/glueckself/MpdClient/README.md
@@ -14,7 +14,7 @@ Control an MPD server
 - Version: 0.11
 - Author: glueckself
 - Maintainers: maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.11
 - Conditions:
   - en
   - de


### PR DESCRIPTION
@glueckself 
each intent has a own function now assigned in self._ACTIONS, since the complexity of onMessage would otherwise get quite big when more intents get added.
Not sure whether this makes sence depending on what how the other functions look, so I leave it here as a idea for further development