### PR TITLE
rewrite modules based on alpha2 functions

### DIFF
--- a/PublishedModules/Jierka/YoutubeJukebox/README.md
+++ b/PublishedModules/Jierka/YoutubeJukebox/README.md
@@ -18,8 +18,10 @@ Allows to play music from youtube
 
 - Version: 1.01
 - Author: Jierka
-- Maintainers: Psycho
-- Alice minimum version: 0.10
+- Maintainers:
+  - Psycho
+  - maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Jierka/YoutubeJukebox/YoutubeJukebox.install
+++ b/PublishedModules/Jierka/YoutubeJukebox/YoutubeJukebox.install
@@ -1,10 +1,10 @@
 {
 	"name": "YoutubeJukebox",
-	"version": 1.0,
+	"version": 1.01,
 	"author": "Jierka",
-	"maintainers": ["Psycho"],
+	"maintainers": ["Psycho", "maxbachmann"],
 	"desc": "Allows to play music from youtube",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [
 		"youtube_dl",

--- a/PublishedModules/Jierka/YoutubeJukebox/YoutubeJukebox.py
+++ b/PublishedModules/Jierka/YoutubeJukebox/YoutubeJukebox.py
@@ -57,7 +57,7 @@ class YoutubeJukebox(Module):
 
 		return clearInput
 
-	
+
 	def searchMusicIntent(self, intent: str, session: DialogSession):
 		siteId = session.siteId
 		sessionId = session.sessionId

--- a/PublishedModules/ProjectAlice/AliceCore/AliceCore.install
+++ b/PublishedModules/ProjectAlice/AliceCore/AliceCore.install
@@ -1,6 +1,6 @@
 {
 	"name": "AliceCore",
-	"version": 1.15,
+	"version": 1.16,
 	"author": "ProjectAlice",
 	"maintainers": [
 		"Psycho",
@@ -8,7 +8,7 @@
 		"maxbachmann"
 	],
 	"desc": "AliceCore is the official module that handles all core intents",
-	"aliceMinVersion": 0.11,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/AliceCore/AliceCore.py
+++ b/PublishedModules/ProjectAlice/AliceCore/AliceCore.py
@@ -206,9 +206,6 @@ class AliceCore(Module):
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('confirmGlobalStop'), siteId=session.siteId)
 			return True
 
-		if not self.filterIntent(intent, session):
-			return False
-
 		siteId = session.siteId
 		slots = session.slots
 		slotsObj = session.slotsAsObjects

--- a/PublishedModules/ProjectAlice/AliceCore/README.md
+++ b/PublishedModules/ProjectAlice/AliceCore/README.md
@@ -17,11 +17,11 @@ wget http://modules.projectalice.ch/AliceCore \
 ### Description
 AliceCore is the official module that handles all core intents
 
-- Version: 1.15
+- Version: 1.16
 - Author: ProjectAlice
 - Maintainers:
   - Psycho, Jierka, maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - EN
   - FR

--- a/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.install
+++ b/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.install
@@ -1,6 +1,6 @@
 {
 	"name": "AliceSatellite",
-	"version": 1.03,
+	"version": 1.04,
 	"author": "ProjectAlice",
 	"maintainers": [
 		"Psycho",
@@ -8,7 +8,7 @@
 		"maxbachmann"
 	],
 	"desc": "AliceSatellite is the official module to support Project Alice satellites",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.py
+++ b/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.py
@@ -48,7 +48,8 @@ class AliceSatellite(Module):
 		payload = session.payload
 		if 'data' in payload:
 			self._sensorReadings[session.siteId] = payload['data']
-	
+
+
 	def deviceDisconnectIntent(self, intent: str, session: DialogSession):
 		payload = session.payload
 		if 'uid' in payload:

--- a/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.py
+++ b/PublishedModules/ProjectAlice/AliceSatellite/AliceSatellite.py
@@ -9,17 +9,17 @@ class AliceSatellite(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._FEEDBACK_SENSORS,
-			self._DEVICE_DISCONNECTION
-		]
+		self._INTENTS = {
+			self._FEEDBACK_SENSORS: self.feedbackSensorIntent,
+			self._DEVICE_DISCONNECTION: self.deviceDisconnectIntent
+		}
 
 		self._sensorReadings = dict()
 
 		self.ProtectedIntentManager.protectIntent(self._FEEDBACK_SENSORS)
 		self.ProtectedIntentManager.protectIntent(self._DEVICE_DISCONNECTION)
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 
 	def onBooted(self):
@@ -43,22 +43,16 @@ class AliceSatellite(Module):
 	def onFullMinute(self):
 		self.getSensorReadings()
 
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
-		if intent == self._FEEDBACK_SENSORS:
-			payload = session.payload
-			if 'data' in payload:
-				self._sensorReadings[session.siteId] = payload['data']
-
-		elif intent == self._DEVICE_DISCONNECTION:
-			payload = session.payload
-			if 'uid' in payload:
-				self.DeviceManager.deviceDisconnecting(payload['uid'])
-
-		return True
+	
+	def feedbackSensorIntent(self, intent: str, session: DialogSession):
+		payload = session.payload
+		if 'data' in payload:
+			self._sensorReadings[session.siteId] = payload['data']
+	
+	def deviceDisconnectIntent(self, intent: str, session: DialogSession):
+		payload = session.payload
+		if 'uid' in payload:
+			self.DeviceManager.deviceDisconnecting(payload['uid'])
 
 
 	def getSensorReadings(self):

--- a/PublishedModules/ProjectAlice/AliceSatellite/README.md
+++ b/PublishedModules/ProjectAlice/AliceSatellite/README.md
@@ -16,11 +16,11 @@ wget http://modules.projectalice.ch/AliceSatellite \
 ### Description
 AliceSatellite is the official module to support Project Alice satellites
 
-- Version: 1.03
+- Version: 1.04
 - Author: ProjectAlice
 - Maintainers:
   - Psycho, Jierka, maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - EN
   - FR

--- a/PublishedModules/ProjectAlice/ContextSensitive/ContextSensitive.install
+++ b/PublishedModules/ProjectAlice/ContextSensitive/ContextSensitive.install
@@ -1,6 +1,6 @@
 {
 	"name": "ContextSensitive",
-	"version": 1.02,
+	"version": 1.03,
 	"author": "ProjectAlice",
 	"maintainers": [
 		"Psycho",
@@ -8,7 +8,7 @@
 		"maxbachmann"
 	],
 	"desc": "ContextSensitive is the official context sensitive module. It handle intents like \"Delete this\", \"Forget about that\"",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/ContextSensitive/README.md
+++ b/PublishedModules/ProjectAlice/ContextSensitive/README.md
@@ -16,11 +16,11 @@ wget http://modules.projectalice.ch/ContextSensitive \
 ### Description
 ContextSensitive is the official context sensitive module. It handle intents like "Delete this", "Forget about that"
 
-- Version: 1.02
+- Version: 1.03
 - Author: ProjectAlice
 - Maintainers:
   - Psycho, Jierka, maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - EN
   - FR

--- a/PublishedModules/ProjectAlice/Customisation/Customisation.install
+++ b/PublishedModules/ProjectAlice/Customisation/Customisation.install
@@ -1,6 +1,6 @@
 {
 	"name": "Customisation",
-	"version": 1.02,
+	"version": 1.03,
 	"author": "ProjectAlice",
 	"maintainers": [
 		"Psycho",
@@ -8,7 +8,7 @@
 		"maxbachmann"
 	],
 	"desc": "A module for anyone to override Project Alice default behavior",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/Customisation/Customisation_sample.py
+++ b/PublishedModules/ProjectAlice/Customisation/Customisation_sample.py
@@ -1,5 +1,4 @@
 from core.base.model.Module import Module
-from core.dialog.model.DialogSession import DialogSession
 
 
 class Customisation(Module):

--- a/PublishedModules/ProjectAlice/Customisation/Customisation_sample.py
+++ b/PublishedModules/ProjectAlice/Customisation/Customisation_sample.py
@@ -13,10 +13,3 @@ class Customisation(Module):
 		self._SUPPORTED_INTENTS = list()
 
 		super().__init__(self._SUPPORTED_INTENTS)
-
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
-		return True

--- a/PublishedModules/ProjectAlice/Customisation/README.md
+++ b/PublishedModules/ProjectAlice/Customisation/README.md
@@ -16,12 +16,12 @@ wget http://modules.projectalice.ch/Customisation \
 ### Description
 Customisation is the official customisation module. Use it to customize your experience
 
-- Version: 1.02
+- Version: 1.03
 - Author: ProjectAlice
 - Maintainers:
   - Psycho
   - Jierka
   - maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions: N/A
 - Requirements: N/A

--- a/PublishedModules/ProjectAlice/RedQueen/README.md
+++ b/PublishedModules/ProjectAlice/RedQueen/README.md
@@ -16,11 +16,11 @@ wget http://modules.projectalice.ch/RedQueen \
 ### Desc
 Red Queen is the official Project Alice personality module
 
-- Version: 1.05
+- Version: 1.06
 - Author: ProjectAlice
 - Maintainers:
   - Psycho, Jierka, maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - EN
   - FR

--- a/PublishedModules/ProjectAlice/RedQueen/RedQueen.install
+++ b/PublishedModules/ProjectAlice/RedQueen/RedQueen.install
@@ -1,6 +1,6 @@
 {
 	"name": "RedQueen",
-	"version": 1.05,
+	"version": 1.06,
 	"author": "ProjectAlice",
 	"maintainers": [
 		"Psycho",
@@ -8,7 +8,7 @@
 		"maxbachmann"
 	],
 	"desc": "Red Queen is the official Project Alice personality module",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/RedQueen/RedQueen.py
+++ b/PublishedModules/ProjectAlice/RedQueen/RedQueen.py
@@ -41,7 +41,7 @@ class RedQueen(Module):
 		if not os.path.isfile(redQueenIdentityFile):
 			if os.path.isfile(redQueenIdentityFileTemplate):
 				shutil.copyfile(redQueenIdentityFileTemplate, redQueenIdentityFile)
-				self._logger.info(f'[{self.name}] New Red Queen is born'.format(self.name))
+				self._logger.info(f'[{self.name}] New Red Queen is born')
 
 				with open(self._getRedQueenIdentityFileName(), 'r') as f:
 					self._redQueen = json.load(f)
@@ -49,10 +49,10 @@ class RedQueen(Module):
 				self._redQueen['infos']['born'] = time.strftime("%d.%m.%Y")
 				self._saveRedQueenIdentity()
 			else:
-				self._logger.info(f'[{self.name}] Cannot find Red Queen identity template'.format(self.name))
+				self._logger.info(f'[{self.name}] Cannot find Red Queen identity template')
 				raise ModuleStartingFailed(moduleName=self.name)
 		else:
-			self._logger.info(f'[{self.name}] Found existing Red Queen identity'.format(self.name))
+			self._logger.info(f'[{self.name}] Found existing Red Queen identity')
 			with open(self._getRedQueenIdentityFileName(), 'r') as f:
 				self._redQueen = json.load(f)
 

--- a/PublishedModules/ProjectAlice/RedQueen/RedQueen.py
+++ b/PublishedModules/ProjectAlice/RedQueen/RedQueen.py
@@ -21,16 +21,16 @@ class RedQueen(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_WHO_ARE_YOU,
-			self._INTENT_GOOD_MORNING,
-			self._INTENT_GOOD_NIGHT,
-			self._INTENT_CHANGE_USER_STATE
-		]
+		self._INTENTS = {
+			self._INTENT_WHO_ARE_YOU: self.whoIntent,
+			self._INTENT_GOOD_MORNING: self.morningIntent,
+			self._INTENT_GOOD_NIGHT: self.nightIntent,
+			self._INTENT_CHANGE_USER_STATE: self.userStateIntent
+		}
 
 		self._redQueen = None
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 
 	def onStart(self):
@@ -41,7 +41,7 @@ class RedQueen(Module):
 		if not os.path.isfile(redQueenIdentityFile):
 			if os.path.isfile(redQueenIdentityFileTemplate):
 				shutil.copyfile(redQueenIdentityFileTemplate, redQueenIdentityFile)
-				self._logger.info('[{}] New Red Queen is born'.format(self.name))
+				self._logger.info(f'[{self.name}] New Red Queen is born'.format(self.name))
 
 				with open(self._getRedQueenIdentityFileName(), 'r') as f:
 					self._redQueen = json.load(f)
@@ -49,14 +49,14 @@ class RedQueen(Module):
 				self._redQueen['infos']['born'] = time.strftime("%d.%m.%Y")
 				self._saveRedQueenIdentity()
 			else:
-				self._logger.info('[{}] Cannot find Red Queen identity template'.format(self.name))
+				self._logger.info(f'[{self.name}] Cannot find Red Queen identity template'.format(self.name))
 				raise ModuleStartingFailed(moduleName=self.name)
 		else:
-			self._logger.info('[{}] Found existing Red Queen identity'.format(self.name))
+			self._logger.info(f'[{self.name}] Found existing Red Queen identity'.format(self.name))
 			with open(self._getRedQueenIdentityFileName(), 'r') as f:
 				self._redQueen = json.load(f)
 
-		return self._SUPPORTED_INTENTS
+		return self._INTENTS
 
 
 	def onStop(self):
@@ -183,51 +183,37 @@ class RedQueen(Module):
 		return True
 
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
+	def whoIntent(self, intent: str, session: DialogSession):
+		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('aliceInfos'), siteId=session.siteId)
 
-		if intent == self._INTENT_CHANGE_USER_STATE:
-			slots = session.slotsAsObjects
-			if 'State' not in slots.keys():
-				self._logger.error('[{}] No state provided for changing user state'.format(self.name))
-				self.endDialog(sessionId=session.sessionId,
-											text=self.TalkManager.randomTalk('error', module='system'),
-											siteId=session.siteId)
-				return True
 
-			if 'Who' in slots.keys():
-				pass
-			else:
-				try:
-					self.ModuleManager.broadcast(slots['State'][0].value['value'])
-				except:
-					self._logger.warning('[{}] Unsupported user state "{}"'.format(self.name, slots['State'][0].value['value']))
+	def morningIntent(self, intent: str, session: DialogSession):
+		self.ModuleManager.broadcast('onWakeup')
+		time.sleep(0.5)
+		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('goodMorning'), siteId=session.siteId)
 
-			self.endDialog(sessionId=session.sessionId,
-										text=self.TalkManager.randomTalk(slots['State'][0].value['value']),
-										siteId=session.siteId)
 
-		elif intent == self._INTENT_GOOD_NIGHT:
-			self.endDialog(sessionId=session.sessionId,
-										text=self.randomTalk('goodNight'),
-										siteId=session.siteId)
+	def nightIntent(self, intent: str, session: DialogSession):
+		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('goodNight'), siteId=session.siteId)
+		self.ModuleManager.broadcast('onSleep')
 
-			self.ModuleManager.broadcast('onSleep')
 
-		elif intent == self._INTENT_GOOD_MORNING:
-			self.ModuleManager.broadcast('onWakeup')
-			time.sleep(0.5)
-			self.endDialog(sessionId=session.sessionId,
-										text=self.randomTalk('goodMorning'),
-										siteId=session.siteId)
+	def userStateIntent(self, intent: str, session: DialogSession):
+		slots = session.slotsAsObjects
+		if 'State' not in slots.keys():
+			self._logger.error(f'[{self.name}] No state provided for changing user state')
+			self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk('error', module='system'), siteId=session.siteId)
+			return
 
-		elif intent == self._INTENT_WHO_ARE_YOU:
-			self.endDialog(sessionId=session.sessionId,
-										text=self.randomTalk('aliceInfos'),
-										siteId=session.siteId)
+		if 'Who' in slots.keys():
+			pass
+		else:
+			try:
+				self.ModuleManager.broadcast(slots['State'][0].value['value'])
+			except:
+				self._logger.warning('[{}] Unsupported user state "{}"'.format(self.name, slots['State'][0].value['value']))
 
-		return True
+		self.endDialog(sessionId=session.sessionId, text=self.TalkManager.randomTalk(slots['State'][0].value['value']), siteId=session.siteId)
 
 
 	def randomlySpeak(self, init: bool = False):
@@ -244,15 +230,15 @@ class RedQueen(Module):
 
 		rnd = random.randint(mini, maxi)
 		self.ThreadManager.doLater(interval=rnd, func=self.randomlySpeak)
-		self._logger.info('[{}] Scheduled next random speaking in {} seconds'.format(self.name, rnd))
+		self._logger.info(f'[{self.name}] Scheduled next random speaking in {rnd} seconds')
 
 		if not init and not self.UserManager.checkIfAllUser('goingBed') and not self.UserManager.checkIfAllUser('sleeping'):
-			self.say(self.randomTalk('randomlySpeak{}'.format(self.mood)), siteId='all')
+			self.say(self.randomTalk(f'randomlySpeak{self.mood}'), siteId='all')
 
 
 	def changeRedQueenStat(self, stat: str, amount: int):
 		if stat not in self._redQueen['stats'].keys():
-			self._logger.warning('[{}] Asked to change stat {} but it does not exist'.format(self.name, stat))
+			self._logger.warning(f'[{self.name}] Asked to change stat {stat} but it does not exist')
 
 		self._redQueen['stats'][stat] += amount
 		if self._redQueen['stats'][stat] < 0:

--- a/PublishedModules/ProjectAlice/Telemetry/README.md
+++ b/PublishedModules/ProjectAlice/Telemetry/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/Telemetry -O ~/ProjectAlice/system/moduleIns
 ### Description
 Access your stored telemetry data
 
-- Version: 0.12
+- Version: 0.13
 - Author: ProjectAlice
 - Maintainers: Psychokiller1888, maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - de

--- a/PublishedModules/ProjectAlice/Telemetry/Telemetry.install
+++ b/PublishedModules/ProjectAlice/Telemetry/Telemetry.install
@@ -1,10 +1,10 @@
 {
 	"name": "Telemetry",
-	"version": 0.12,
+	"version": 0.13,
 	"author": "ProjectAlice",
 	"maintainers": ["Psychokiller1888", "maxbachmann"],
 	"desc": "Access your stored telemetry data",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"pipRequirements": [],
 	"systemRequirements": [],
 	"conditions": {

--- a/PublishedModules/ProjectAlice/Telemetry/Telemetry.py
+++ b/PublishedModules/ProjectAlice/Telemetry/Telemetry.py
@@ -13,12 +13,12 @@ class Telemetry(Module):
 	_INTENT_ANSWER_TELEMETRY_TYPE = Intent('AnswerTelemetryType')
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS	= [
-			self._INTENT_GET_TELEMETRY_DATA,
-			self._INTENT_ANSWER_TELEMETRY_TYPE
-		]
+		self._INTENTS	= {
+			self._INTENT_GET_TELEMETRY_DATA: self.telemetryIntent,
+			self._INTENT_ANSWER_TELEMETRY_TYPE: self.telemetryIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 		self._telemetryUnits = {
 			'airQuality': '%',
@@ -35,33 +35,27 @@ class Telemetry(Module):
 			'wind_strength': 'km/h'
 		}
 
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
-		siteId = session.siteId
+	
+	def telemetryIntent(self, intent: str, session: DialogSession):
 		slots = session.slots
+		siteId = session.siteId
 
-		if intent in {self._INTENT_GET_TELEMETRY_DATA, self._INTENT_ANSWER_TELEMETRY_TYPE}:
-			if 'siteId' in slots:
-				siteId = session.slotValue('Room')
+		if 'siteId' in slots:
+			siteId = session.slotValue('Room')
 
-			if 'TelemetryType' not in slots:
-				self.continueDialog(
-					sessionId=session.sessionId,
-					text=self.randomTalk('noType'),
-					intentFilter=[self._INTENT_ANSWER_TELEMETRY_TYPE],
-					slot='TelemetryType'
-				)
+		if 'TelemetryType' not in slots:
+			self.continueDialog(
+				sessionId=session.sessionId,
+				text=self.randomTalk('noType'),
+				intentFilter=[self._INTENT_ANSWER_TELEMETRY_TYPE],
+				slot='TelemetryType'
+			)
 
-			telemetryType = session.slotValue('TelemetryType')
+		telemetryType = session.slotValue('TelemetryType')
 
-			data = self.TelemetryManager.getData(siteId=siteId, ttype=telemetryType)
-			if data and 'value' in data:
-				answer = data['value'] + self._telemetryUnits.get(telemetryType, '')
-				self.endDialog(sessionId=session.sessionId, text=self.randomTalk('answerInstant').format(answer))
-			else:
-				self.endDialog(sessionId=session.sessionId, text=self.randomTalk('noData'))
-
-		return True
+		data = self.TelemetryManager.getData(siteId=siteId, ttype=telemetryType)
+		if data and 'value' in data:
+			answer = data['value'] + self._telemetryUnits.get(telemetryType, '')
+			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('answerInstant').format(answer))
+		else:
+			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('noData'))

--- a/PublishedModules/ProjectAlice/Telemetry/Telemetry.py
+++ b/PublishedModules/ProjectAlice/Telemetry/Telemetry.py
@@ -35,7 +35,7 @@ class Telemetry(Module):
 			'wind_strength': 'km/h'
 		}
 
-	
+
 	def telemetryIntent(self, intent: str, session: DialogSession):
 		slots = session.slots
 		siteId = session.siteId

--- a/PublishedModules/Psychokiller1888/Calculator/Calculator.install
+++ b/PublishedModules/Psychokiller1888/Calculator/Calculator.install
@@ -1,13 +1,13 @@
 {
 	"name": "Calculator",
-	"version": 1.11,
+	"version": 1.12,
 	"author": "Psychokiller1888",
 	"maintainers": [
 		"maxbachmann",
 		"Jierka"
 	],
 	"desc": "Do some calculation with alice",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/Calculator/Calculator.py
+++ b/PublishedModules/Psychokiller1888/Calculator/Calculator.py
@@ -17,51 +17,45 @@ class Calculator(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_MATHS
-		]
+		self._INTENTS = {
+			self._INTENT_MATHS: self.mathIntent
+		}
 		self._lastNumber: Optional[float] = None
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
+	def mathIntent(self, intent: str, session: DialogSession):
 		slots = session.slotsAsObjects
 		sessionId = session.sessionId
 
-		if intent == self._INTENT_MATHS:
-			if ('Left' not in slots and 'Right' not in slots) or 'Function' not in slots:
-				self.continueDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('notUnderstood'))
-				return True
+		if ('Left' not in slots and 'Right' not in slots) or 'Function' not in slots:
+			self.continueDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('notUnderstood'))
+			return
 
-			func = slots['Function'][0].value['value']
+		func = slots['Function'][0].value['value']
 
-			if 'Left' in slots and 'Right' in slots:
-				result = self.calculate(float(slots['Left'][0].value['value']), float(slots['Right'][0].value['value']), func)
+		if 'Left' in slots and 'Right' in slots:
+			result = self.calculate(float(slots['Left'][0].value['value']), float(slots['Right'][0].value['value']), func)
 
-			elif 'Right' in slots and 'Left' not in slots:
-				if not isinstance(self._lastNumber, numbers.Number):
-					self.endDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('noPreviousOperation'))
-					return True
+		elif 'Right' in slots and 'Left' not in slots:
+			if not isinstance(self._lastNumber, numbers.Number):
+				self.endDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('noPreviousOperation'))
+				return
 
-				result = self.calculate(float(self._lastNumber), float(slots['Right'][0].value['value']), func)
+			result = self.calculate(float(self._lastNumber), float(slots['Right'][0].value['value']), func)
 
-			else:
-				self.continueDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('notUnderstood'))
-				return True
+		else:
+			self.continueDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('notUnderstood'))
+			return
 
-			if not isinstance(result, numbers.Number):
-				answer = 'not supported'
-			elif result % 1 == 0:
-				answer = str(int(result))
-			else:
-				answer = str(result)
+		if not isinstance(result, numbers.Number):
+			answer = 'not supported'
+		elif result % 1 == 0:
+			answer = str(int(result))
+		else:
+			answer = str(result)
 
-			self.endDialog(sessionId=sessionId, text=answer)
-
-		return True
+		self.endDialog(sessionId=sessionId, text=answer)
 
 
 	def calculate(self, left: float, right: float, func: str) -> Optional[float]:

--- a/PublishedModules/Psychokiller1888/Calculator/README.md
+++ b/PublishedModules/Psychokiller1888/Calculator/README.md
@@ -16,12 +16,12 @@ wget modules.projectalice.ch/Calculator \
 ### Description
 Do some calculation with alice
 
-- Version: 1.11
+- Version: 1.12
 - Author: Psychokiller1888
 - Maintainers:
   - Jierka
   - maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - de

--- a/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.install
+++ b/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.install
@@ -1,13 +1,13 @@
 {
 	"name": "DateDayTimeYear",
-	"version": 1.01,
+	"version": 1.02,
 	"author": "Psychokiller1888",
 	"maintainers": [
 		"Jierka",
 		"maxbachmann"
 	],
 	"desc": "Ask for the time, date, day and year",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
+++ b/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
@@ -13,35 +13,17 @@ class DateDayTimeYear(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_GET_TIME,
-			self._INTENT_GET_DATE,
-			self._INTENT_GET_DAY,
-			self._INTENT_GET_YEAR
-		]
+		self._INTENTS = {
+			self._INTENT_GET_TIME: self.timeIntent,
+			self._INTENT_GET_DATE: self.dateIntent,
+			self._INTENT_GET_DAY: self.dayIntent,
+			self._INTENT_GET_YEAR: self.yearIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
-
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
-		sessionId = session.sessionId
-
-		if intent == self._INTENT_GET_TIME:
-			self.timeIntent(sessionId)
-		elif intent == self._INTENT_GET_DATE:
-			self.dateIntent(sessionId)
-		elif intent == self._INTENT_GET_DAY:
-			self.dayIntent(sessionId)
-		elif intent == self._INTENT_GET_YEAR:
-			self.yearIntent(sessionId)
-
-		return True
+		super().__init__(self._INTENTS)
 
 
-	def timeIntent(self, sessionId: str):
+	def timeIntent(self, intent: str, session: DialogSession):
 		minutes = datetime.now().strftime('%M').lstrip('0')
 		part = datetime.now().strftime('%p')
 
@@ -49,25 +31,25 @@ class DateDayTimeYear(Module):
 		if self.LanguageManager.activeLanguage == 'en':
 			hours = datetime.now().strftime('%I').lstrip('0')
 			if minutes != '' and int(minutes) < 10:
-				minutes = 'oh {}'.format(minutes)
+				minutes = f'oh {minutes}'
 		else:
 			hours = datetime.now().strftime('%H').lstrip('0')
 
-		self.endDialog(sessionId, self.TalkManager.randomTalk('time').format(hours, minutes, part))
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('time').format(hours, minutes, part))
 
 
-	def dateIntent(self, sessionId: str):
+	def dateIntent(self, intent: str, session: DialogSession):
 		date = datetime.now().strftime('%d %B %Y')
 		date = self.LanguageManager.localize(date)
-		self.endDialog(sessionId, self.TalkManager.randomTalk('date').format(date))
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('date').format(date))
 
 
-	def dayIntent(self, sessionId: str):
+	def dayIntent(self, intent: str, session: DialogSession):
 		day = datetime.now().strftime('%A')
 		day = self.LanguageManager.localize(day)
-		self.endDialog(sessionId, self.TalkManager.randomTalk('day').format(day))
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('day').format(day))
 
 
-	def yearIntent(self, sessionId: str):
+	def yearIntent(self, intent: str, session: DialogSession):
 		year = datetime.now().strftime('%Y')
-		self.endDialog(sessionId, self.TalkManager.randomTalk('day').format(year))
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('day').format(year))

--- a/PublishedModules/Psychokiller1888/DateDayTimeYear/README.md
+++ b/PublishedModules/Psychokiller1888/DateDayTimeYear/README.md
@@ -16,12 +16,12 @@ wget http://bit.ly/DateDayTimeYear \
 ### Description
 Ask for the time, date, day and year
 
-- Version: 1.01
+- Version: 1.02
 - Author: Psycho
 - Maintainers:
   - Jierka
   - maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/FindMyPhone/FindMyPhone.install
+++ b/PublishedModules/Psychokiller1888/FindMyPhone/FindMyPhone.install
@@ -1,10 +1,10 @@
 {
 	"name": "FindMyPhone",
-	"version": 1.01,
+	"version": 1.02,
 	"author": "Psychokiller1888",
 	"maintainers": ["maxbachmann"],
 	"desc": "Using ifttt one can ask Alice to find his phone. sets the ring tone at max volume and initiates a call on it.",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/FindMyPhone/FindMyPhone.py
+++ b/PublishedModules/Psychokiller1888/FindMyPhone/FindMyPhone.py
@@ -26,9 +26,6 @@ class FindMyPhone(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		sessionId = session.sessionId
 		slots = session.slots
 

--- a/PublishedModules/Psychokiller1888/FindMyPhone/README.md
+++ b/PublishedModules/Psychokiller1888/FindMyPhone/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/FindMyPhone -O ~/ProjectAlice/system/moduleI
 ### Description
 Using ifttt one can ask alice to find his phone. sets the ring tone at max volume and initiates a call on it.
 
-- Version: 1.01
+- Version: 1.02
 - Author: Psychokiller1888
 - Maintainers: maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/FreeCurrencyConverterDotCom.install
+++ b/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/FreeCurrencyConverterDotCom.install
@@ -1,10 +1,10 @@
 {
 	"name": "FreeCurrencyConverterDotCom",
-	"version": 1.23,
+	"version": 1.24,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "Let's you convert world currencies",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/FreeCurrencyConverterDotCom.py
+++ b/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/FreeCurrencyConverterDotCom.py
@@ -27,9 +27,6 @@ class FreeCurrencyConverterDotCom(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		siteId = session.siteId
 		slots = session.slots
 		slotsObject = session.slotsAsObjects
@@ -69,15 +66,14 @@ class FreeCurrencyConverterDotCom(Module):
 				fromCurrency = slotsObject['FromCurrency'][0].value['value']
 
 			try:
-				url = 'https://free.currconv.com/api/v7/convert?q={}_{}&compact=ultra&apiKey={}'.format(fromCurrency, toCurrency, self.getConfig('apiKey'))
+				url = f"https://free.currconv.com/api/v7/convert?q={fromCurrency}_{toCurrency}&compact=ultra&apiKey={self.getConfig('apiKey')}"
 				req = requests.get(url=url)
 				data = json.loads(req.content.decode())
 
-				conversion = data['{}_{}'.format(fromCurrency, toCurrency)]
+				conversion = data[f'{fromCurrency}_{toCurrency}']
 				converted = round(float(amount) * float(conversion), 2)
 
-				self.endDialog(sessionId, text=self.randomTalk('answer').format(amount, fromCurrency, converted, toCurrency),
-											siteId=siteId)
+				self.endDialog(sessionId, text=self.randomTalk('answer').format(amount, fromCurrency, converted, toCurrency), siteId=siteId)
 			except Exception as e:
 				self._logger.error(e)
 				self.endDialog(sessionId, text=self.randomTalk('noServer'), siteId=siteId)

--- a/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/README.md
+++ b/PublishedModules/Psychokiller1888/FreeCurrencyConverterDotCom/README.md
@@ -16,10 +16,10 @@ wget http://modules.projectalice.ch/FreeCurrencyConverterDotCom \
 ### Description
 Let's you convert world currencies
 
-- Version: 1.23
+- Version: 1.24
 - Author: Psychokiller1888
-- Maintainers: N/A
-- Alice minimum version: 0.10
+- Maintainers: maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
 - Requirements: N/A

--- a/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/IcanhazdadjokeDotCom.install
+++ b/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/IcanhazdadjokeDotCom.install
@@ -1,10 +1,10 @@
 {
 	"name": "IcanhazdadjokeDotCom",
-	"version": 1.12,
+	"version": 1.13,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann", "Jierka"],
 	"desc": "Get a random dad joke on demand!",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/IcanhazdadjokeDotCom.py
+++ b/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/IcanhazdadjokeDotCom.py
@@ -3,25 +3,26 @@ import requests
 from core.base.model.Intent import Intent
 from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
+from core.commons.commons import online
 
 
 class IcanhazdadjokeDotCom(Module):
 	_INTENT_TELL_A_JOKE = Intent('TellAJoke')
 
-
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_TELL_A_JOKE
-		]
+		self._INTENTS = {
+			self._INTENT_TELL_A_JOKE: self.jokeIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
+	def offlineHandler(self, session: DialogSession, **kwargs):
+		self.endDialog(session.sessionId, text=self.TalkManager.randomTalk('offline', module='system'))
 
-		if intent == self._INTENT_TELL_A_JOKE:
+
+	@online(offlineHandler=offlineHandler)
+	def jokeIntent(self, intent: str, session: DialogSession):
 			url = 'https://icanhazdadjoke.com/'
 
 			headers = {
@@ -35,5 +36,3 @@ class IcanhazdadjokeDotCom(Module):
 				self.endDialog(session.sessionId, text=response.text)
 			else:
 				self.endDialog(session.sessionId, self.TalkManager.getrandomTalk('noJoke'))
-
-		return True

--- a/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/README.md
+++ b/PublishedModules/Psychokiller1888/IcanhazdadjokeDotCom/README.md
@@ -16,11 +16,12 @@ wget http://modules.projectalice.ch/IcanhazdadjokeDotCom \
 ### Description
 Get a random dad joke on demand
 
-- Version: 1.12
+- Version: 1.13
 - Author: Psycho
 - Maintainers:
   - Jierka
-- Alice minimum version: 0.10
+  - maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
 - Requirements: N/A

--- a/PublishedModules/Psychokiller1888/Ifttt/Ifttt.install
+++ b/PublishedModules/Psychokiller1888/Ifttt/Ifttt.install
@@ -1,10 +1,10 @@
 {
 	"name": "Ifttt",
-	"version": 1.01,
+	"version": 1.02,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "Use ifttt services",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/Ifttt/Ifttt.py
+++ b/PublishedModules/Psychokiller1888/Ifttt/Ifttt.py
@@ -42,14 +42,10 @@ class Ifttt(Module):
 			result = self.databaseFetch(tableName='ifttt', query='SELECT * FROM :__table__ WHERE user = :user', values={'user': user.lower()})
 
 			if result:
-				answer = requests.post(url='https://maker.ifttt.com/trigger/{}/with/key/{}'.format(endPoint, result['key']))
+				answer = requests.post(url=f"https://maker.ifttt.com/trigger/{endPoint}/with/key/{result['key']}")
 				return IftttException.OK if answer.status_code == 200 else IftttException.BAD_REQUEST
 
 			return IftttException.NO_USER
 		except Exception as e:
-			self._logger.error('[{}] Error trying to request api: {}'.format(self.name, e))
+			self._logger.error(f'[{self.name}] Error trying to request api: {e}')
 			return IftttException.ERROR
-
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		return False

--- a/PublishedModules/Psychokiller1888/Ifttt/Ifttt.py
+++ b/PublishedModules/Psychokiller1888/Ifttt/Ifttt.py
@@ -2,7 +2,6 @@ import requests
 from enum import Enum
 
 from core.base.model.Module import Module
-from core.dialog.model.DialogSession import DialogSession
 
 
 class IftttException(Enum):

--- a/PublishedModules/Psychokiller1888/Ifttt/README.md
+++ b/PublishedModules/Psychokiller1888/Ifttt/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/ifttt -O ~/ProjectAlice/system/moduleInstall
 ### Description
 Use ifttt services
 
-- Version: 1.01
+- Version: 1.02
 - Author: Psychokiller1888
-- Maintainers: N/A
-- Alice minimum version: 0.10
+- Maintainers: maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - online
 - Requirements: N/A

--- a/PublishedModules/Psychokiller1888/Minigames/Minigames.py
+++ b/PublishedModules/Psychokiller1888/Minigames/Minigames.py
@@ -47,13 +47,13 @@ class Minigames(Module):
 
 		for game in self._SUPPORTED_GAMES:
 			try:
-				lib = importlib.import_module('modules.Minigames.model.{}'.format(game))
+				lib = importlib.import_module(f'modules.Minigames.model.{game}')
 				klass = getattr(lib, game)
 				minigame = klass()
 				self._minigames[game] = minigame
 				self._SUPPORTED_INTENTS += minigame.intents
 			except Exception as e:
-				self._logger.error('[{}] Something went wrong loading the minigame "{}": {}'.format(self.name, game, e))
+				self._logger.error(f'[{self.name}] Something went wrong loading the minigame "{game}": {e}')
 
 
 	def onSessionTimeout(self, session: DialogSession):

--- a/PublishedModules/Psychokiller1888/Netatmo/Netatmo.install
+++ b/PublishedModules/Psychokiller1888/Netatmo/Netatmo.install
@@ -1,10 +1,10 @@
 {
 	"name": "Netatmo",
-	"version": 1.01,
+	"version": 1.02,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "Get readings from your netatmo hardware",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"pipRequirements": [
 		"lnetatmo"
 	],

--- a/PublishedModules/Psychokiller1888/Netatmo/Netatmo.py
+++ b/PublishedModules/Psychokiller1888/Netatmo/Netatmo.py
@@ -27,17 +27,17 @@ class Netatmo(Module):
 	def onStart(self) -> list:
 		super().onStart()
 		if not self.getConfig('password'):
-			raise ModuleStartingFailed(moduleName=self.name, error='[{}] No credentials provided'.format(self.name))
+			raise ModuleStartingFailed(moduleName=self.name, error=f'[{self.name}] No credentials provided')
 
 		if self._auth():
 			try:
 				self._weatherData = lnetatmo.WeatherStationData(self._netatmoAuth)
 			except lnetatmo.NoDevice:
-				raise ModuleStartingFailed(moduleName=self.name, error='[{}] No Netatmo device found'.format(self.name))
+				raise ModuleStartingFailed(moduleName=self.name, error=f'[{self.name}] No Netatmo device found')
 			else:
 				return self._SUPPORTED_INTENTS
 		else:
-			raise ModuleStartingFailed(moduleName=self.name, error='[{}] Authentication failed'.format(self.name))
+			raise ModuleStartingFailed(moduleName=self.name, error=f'[{self.name}] Authentication failed')
 
 
 	def _auth(self) -> bool:
@@ -53,7 +53,7 @@ class Netatmo(Module):
 		except lnetatmo.AuthFailure:
 			self._authTries += 1
 			if self._authTries >= 3:
-				self._logger.warning('[{}] Tried to auth 3 times, giving up now'.format(self.name))
+				self._logger.warning(f'[{self.name}] Tried to auth 3 times, giving up now')
 				return False
 			else:
 				time.sleep(1)
@@ -102,7 +102,3 @@ class Netatmo(Module):
 
 			if 'GustAngle' in value:
 				self.TelemetryManager.storeData(ttype=TelemetryType.GUST_ANGLE, value=value['GustAngle'], service=self.name, siteId=siteId, timestamp=now)
-
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		return False

--- a/PublishedModules/Psychokiller1888/Netatmo/Netatmo.py
+++ b/PublishedModules/Psychokiller1888/Netatmo/Netatmo.py
@@ -4,7 +4,6 @@ import lnetatmo
 
 from core.ProjectAliceExceptions import ModuleStartingFailed
 from core.base.model.Module import Module
-from core.dialog.model.DialogSession import DialogSession
 from core.util.model.TelemetryType import TelemetryType
 
 

--- a/PublishedModules/Psychokiller1888/Netatmo/README.md
+++ b/PublishedModules/Psychokiller1888/Netatmo/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/Netatmo -O ~/ProjectAlice/system/moduleInsta
 ### Description
 Get readings from your netatmo hardware
 
-- Version: 1.01
+- Version: 1.02
 - Author: Psychokiller1888
-- Maintainers: N/A
-- Alice minimum version: 0.10
+- Maintainers: maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/PhilipsHue/PhilipsHue.install
+++ b/PublishedModules/Psychokiller1888/PhilipsHue/PhilipsHue.install
@@ -1,12 +1,13 @@
 {
 	"name": "PhilipsHue",
-	"version": 1.24,
+	"version": 1.25,
 	"author": "Psychokiller1888",
 	"maintainers": [
-		"Jierka"
+		"Jierka",
+		"maxbachmann"
 	],
 	"desc": "Control your Philips Hue lamps",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/PhilipsHue/PhilipsHue.py
+++ b/PublishedModules/Psychokiller1888/PhilipsHue/PhilipsHue.py
@@ -59,16 +59,16 @@ class PhilipsHue(Module):
 				request = requests.get('https://www.meethue.com/api/nupnp')
 				response = request.json()
 				firstBridge = response[0]
-				self._logger.info("- [{}] Autodiscover found bridge at {}, saving ip to config.json".format(self.name, firstBridge['internalipaddress']))
+				self._logger.info(f"- [{self.name}] Autodiscover found bridge at {firstBridge['internalipaddress']}, saving ip to config.json")
 				self.updateConfig('phueAutodiscoverFallback', False)
 				self.updateConfig('phueBridgeIp', firstBridge['internalipaddress'])
 				if not self._connectBridge():
-					raise ModuleStartingFailed(moduleName=self.name, error='[{}] Cannot connect to bridge'.format(self.name))
+					raise ModuleStartingFailed(moduleName=self.name, error=f'[{self.name}] Cannot connect to bridge')
 				return self._SUPPORTED_INTENTS
 			except IndexError:
-				self._logger.info("- [{}] No bridge found".format(self.name))
+				self._logger.info(f'- [{self.name}] No bridge found')
 
-		raise ModuleStartingFailed(moduleName=self.name, error='[{}] Cannot connect to bridge'.format(self.name))
+		raise ModuleStartingFailed(moduleName=self.name, error=f'[{self.name}] Cannot connect to bridge')
 
 
 	def _connectBridge(self) -> bool:
@@ -78,7 +78,7 @@ class PhilipsHue(Module):
 				hueConfigFileExists = os.path.isfile(hueConfigFile)
 
 				if not hueConfigFileExists:
-					self._logger.info('- [{}] No philipsHueConf.conf file in PhilipsHue module directory'.format(self.name))
+					self._logger.info(f'- [{self.name}] No philipsHueConf.conf file in PhilipsHue module directory')
 
 				self._bridge = Bridge(ip=self.ConfigManager.getModuleConfigByName(self.name, 'phueBridgeIp'), config_file_path=hueConfigFile)
 
@@ -100,17 +100,17 @@ class PhilipsHue(Module):
 				if self.delayed:
 					self.say(text=self.randomTalk('pressBridgeButton'))
 					self._bridgeConnectTries += 1
-					self._logger.warning("- [{}] Bridge not registered, please press the bridge button, retry in 20 seconds".format(self.name))
+					self._logger.warning(f"- [{self.name}] Bridge not registered, please press the bridge button, retry in 20 seconds")
 					time.sleep(20)
 					return self._connectBridge()
 				else:
 					self.delayed = True
 					raise ModuleStartDelayed(self.name)
 			except PhueException as e:
-				self._logger.error('- [{}] Bridge error: {}'.format(self.name, e))
+				self._logger.error(f'- [{self.name}] Bridge error: {e}')
 				return False
 		else:
-			self._logger.error("- [{}] Couldn't reach bridge".format(self.name))
+			self._logger.error(f"- [{self.name}] Couldn't reach bridge")
 			self.ThreadManager.doLater(interval=3, func=self.say, args=[self.randomTalk('pressBridgeButtonTimeout')])
 			return False
 
@@ -128,7 +128,7 @@ class PhilipsHue(Module):
 			self._scenes[scene.name.lower()] = scene
 
 		if self._house is None:
-			self._logger.warning('- [{}] Coulnd\'t find any group named "House". Creating one'.format(self.name))
+			self._logger.warning(f'- [{self.name}] Coulnd\'t find any group named "House". Creating one')
 			self._bridge.create_group(name='House', lights=self._bridge.get_light().keys(), )
 
 		return True
@@ -167,9 +167,6 @@ class PhilipsHue(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		siteId = session.siteId
 		slots = session.slotsAsObjects
 		sessionId = session.sessionId

--- a/PublishedModules/Psychokiller1888/PhilipsHue/README.md
+++ b/PublishedModules/Psychokiller1888/PhilipsHue/README.md
@@ -16,11 +16,12 @@ wget http://modules.projectalice.ch/PhilipsHue \
 ### Desc
 Control your Philips Hue lamps
 
-- Version: 1.24
+- Version: 1.25
 - Author: Psycho
 - Maintainers:
   - Jierka
-- Alice minimum version: 0.10
+  - maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
 

--- a/PublishedModules/Psychokiller1888/RandomUselessFacts/README.md
+++ b/PublishedModules/Psychokiller1888/RandomUselessFacts/README.md
@@ -16,11 +16,11 @@ wget http://modules.projectalice.ch/RandomUselessFacts \
 ### Description
 Gets you the daily random useless fact or a random one
 
-- Version: 1.41
+- Version: 1.42
 - Author: Psychokiller1888
 - Maintainers:
   - maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - de

--- a/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.install
+++ b/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.install
@@ -1,12 +1,12 @@
 {
 	"name": "RandomUselessFacts",
-	"version": 1.41,
+	"version": 1.42,
 	"author": "Psychokiller1888",
 	"maintainers": [
 		"maxbachmann"
 	],
 	"desc": "Gets you the daily random useless fact or a random one",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.py
+++ b/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.py
@@ -1,5 +1,4 @@
 import html
-import json
 
 import requests
 

--- a/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.py
+++ b/PublishedModules/Psychokiller1888/RandomUselessFacts/RandomUselessFacts.py
@@ -19,34 +19,29 @@ class RandomUselessFacts(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_GET_USELESS_FACT
-		]
+		self._INTENTS = {
+			self._INTENT_GET_USELESS_FACT: self.uselessFactIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
+	def offlineHandler(self, session: DialogSession, **kwargs):
+		self.endDialog(session.sessionId, text=self.TalkManager.randomTalk('offline', module='system'))
 
-		if intent == self._INTENT_GET_USELESS_FACT:
-			if not 'type' in session.slots:
-				ttype = 'random'
-			else:
-				ttype = session.slotsAsObjects['type'][0].value['value']
 
-			self.endDialog(sessionId=session.sessionId, text=self.getAFact(ttype=ttype))
+	@online(offlineHandler=offlineHandler)
+	def uselessFactIntent(self, intent: str, session: DialogSession):
+		if not 'type' in session.slots:
+			ttype = 'random'
+		else:
+			ttype = session.slotsAsObjects['type'][0].value['value']
 
-		return True
-
-	@online
-	def getAFact(self, ttype: str) -> str:
 		# Try to fetch a fact
-		req = requests.request(method='GET', url='https://uselessfacts.jsph.pl/{}.json?language={}'.format(ttype, self.activeLanguage()))
+		req = requests.request(method='GET', url=f'https://uselessfacts.jsph.pl/{ttype}.json?language={self.activeLanguage()}')
 		if req.status_code != 200:
 			# Failed, maybe the server is offline?
-			return self.randomTalk('error')
+			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('error'))
 		else:
 			# Let's load the randomTalk and unescape it as uselessfact seems to encode special characters for german
-			return html.unescape(json.loads(req.content)['text'])
+			self.endDialog(sessionId=session.sessionId, text=html.unescape(req.json()['text']))

--- a/PublishedModules/Psychokiller1888/Speller/README.md
+++ b/PublishedModules/Psychokiller1888/Speller/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/Speller -O ~/ProjectAlice/system/moduleInsta
 ### Description
 Ask alice how to spell any word!
 
-- Version: 1.0
+- Version: 1.01
 - Author: Psychokiller1888
-- Maintainers: N/A
-- Alice minimum version: 0.10
+- Maintainers: maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/Speller/Speller.install
+++ b/PublishedModules/Psychokiller1888/Speller/Speller.install
@@ -1,10 +1,10 @@
 {
 	"name": "Speller",
-	"version": 1.0,
+	"version": 1.01,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "Ask alice how to spell any word!",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"pipRequirements": [],
 	"systemRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/Speller/Speller.py
+++ b/PublishedModules/Psychokiller1888/Speller/Speller.py
@@ -22,9 +22,6 @@ class Speller(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		sessionId = session.sessionId
 		slots = session.slots
 

--- a/PublishedModules/Psychokiller1888/Tasmota/README.md
+++ b/PublishedModules/Psychokiller1888/Tasmota/README.md
@@ -16,11 +16,11 @@ wget http://modules.projectalice.ch/Tasmota \
 ### Description
 This module allows you to not only connect tasmota esp devices, but listen to them
 
-- Version: 1.32
+- Version: 1.33
 - Author: Psychokiller1888
 - Maintainers:
   - maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/Tasmota/Tasmota.install
+++ b/PublishedModules/Psychokiller1888/Tasmota/Tasmota.install
@@ -1,10 +1,10 @@
 {
 	"name": "Tasmota",
-	"version": 1.32,
+	"version": 1.33,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "This module allows you to not only connect tasmota esp devices, but listen to them",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/Psychokiller1888/Tasmota/Tasmota.py
+++ b/PublishedModules/Psychokiller1888/Tasmota/Tasmota.py
@@ -41,7 +41,7 @@ class Tasmota(Module):
 		if intent.startswith('projectalice/devices/tasmota/'):
 			return True
 		super().filterIntent(intent=intent, session=session)
-		
+
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
 		siteId = session.siteId

--- a/PublishedModules/Psychokiller1888/Tasmota/Tasmota.py
+++ b/PublishedModules/Psychokiller1888/Tasmota/Tasmota.py
@@ -37,10 +37,13 @@ class Tasmota(Module):
 		super().__init__(self._SUPPORTED_INTENTS)
 
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not intent.startswith('projectalice/devices/tasmota/') and not self.filterIntent(intent, session):
-			return False
+	def filterIntent(self, intent: str, session: DialogSession) -> bool:
+		if intent.startswith('projectalice/devices/tasmota/'):
+			return True
+		super().filterIntent(intent=intent, session=session)
+		
 
+	def onMessage(self, intent: str, session: DialogSession) -> bool:
 		siteId = session.siteId
 		payload = session.payload
 
@@ -48,12 +51,12 @@ class Tasmota(Module):
 			identifier = self._connectingRegex.match(intent).group(1)
 			if self.DeviceManager.getDeviceByUID(identifier):
 				# This device is known
-				self._logger.info('[{}] A device just connected in {}'.format(self.name, siteId))
+				self._logger.info(f'[{self.name}] A device just connected in {siteId}')
 				self.DeviceManager.deviceConnecting(uid=identifier)
 			else:
 				# We did not ask Alice to add a new device
 				if not self.DeviceManager.broadcastFlag.isSet():
-					self._logger.warning('[{}] A device is trying to connect to Alice but is unknown'.format(self.name))
+					self._logger.warning(f'[{self.name}] A device is trying to connect to Alice but is unknown')
 
 		elif self._feedbackRegex.match(intent):
 			if 'feedback' in payload:

--- a/PublishedModules/Psychokiller1888/Wikipedia/README.md
+++ b/PublishedModules/Psychokiller1888/Wikipedia/README.md
@@ -16,10 +16,12 @@ wget http://modules.projectalice.ch/Wikipedia \
 ### Description
 Allows one to find informations about a topic on wikipedia
 
-- Version: 1.34
+- Version: 1.35
 - Author: Psychokiller1888
-- Maintainers: Jierka
-- Alice minimum version: 0.10
+- Maintainers:
+    - Jierka
+    - maxbachmann
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - fr

--- a/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.install
+++ b/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.install
@@ -1,10 +1,10 @@
 {
 	"name": "Wikipedia",
-	"version": 1.34,
+	"version": 1.35,
 	"author": "Psychokiller1888",
-	"maintainers": ["Jierka"],
+	"maintainers": ["Jierka", "maxbachmann"],
 	"desc": "Allows one to find informations about a topic on wikipedia",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [
 		"wikipedia",

--- a/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.py
+++ b/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.py
@@ -27,9 +27,6 @@ class Wikipedia(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		slots = session.slots
 		sessionId = session.sessionId
 		customData = session.customData
@@ -99,7 +96,7 @@ class Wikipedia(Module):
 					)
 					return True
 				except Exception as e:
-					self._logger.error('Error: {}'.format(e))
+					self._logger.error(f'Error: {e}')
 					self.endDialog(sessionId=sessionId, text=self.TalkManager.randomTalk('error', module='system'))
 					return True
 

--- a/PublishedModules/Psychokiller1888/Zigbee2Mqtt/README.md
+++ b/PublishedModules/Psychokiller1888/Zigbee2Mqtt/README.md
@@ -16,10 +16,10 @@ wget http://bit.ly/????????? -O ~/ProjectAlice/system/moduleInstallTickets/Zigbe
 
 Have your zigbee devices communicate with alice directly over mqtt
 
-- Version: 1.0
+- Version: 0.11
 - Author: Psychokiller1888
-- Maintainers: N/A
-- Alice minimum version: 0.10
+- Maintainers: maxbachmann
+- Alice minimum version: 0.12
 - Conditions: N/A
 - Pip requirements: N/A
 - System requirements: nodejs make g++ gcc

--- a/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.install
+++ b/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.install
@@ -1,10 +1,10 @@
 {
 	"name": "Zigbee2Mqtt",
-	"version": 0.1,
+	"version": 0.11,
 	"author": "Psychokiller1888",
-	"maintainers": [],
+	"maintainers": ["maxbachmann"],
 	"desc": "Have your zigbee devices communicate with alice directly over mqtt",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"pipRequirements": [],
 	"systemRequirements": [
 		"nodejs",

--- a/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.py
+++ b/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.py
@@ -30,7 +30,8 @@ class Zigbee2Mqtt(Module):
 
 
 	def onModuleInstalled(self):
-		service = """[Unit]
+		service = f"""\
+[Unit]
 Description=zigbee2mqtt
 After=network.target
 
@@ -40,16 +41,12 @@ WorkingDirectory=/opt/zigbee2mqtt
 StandardOutput=inherit
 StandardError=inherit
 Restart=always
-User={}
+User={getpass.getuser()}
 
 [Install]
-WantedBy=multi-user.target""".format(getpass.getuser())
+WantedBy=multi-user.target"""
 
 		filepath = Path(commons.rootDir(), 'zigbee2mqtt.service')
 		filepath.write_text(service)
 		subprocess.run(['sudo', 'mv', str(filepath), '/etc/systemd/system/zigbee2mqtt.service'])
 		subprocess.run(['sudo', 'systemctl', 'daemon-reload'])
-
-
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		return False

--- a/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.py
+++ b/PublishedModules/Psychokiller1888/Zigbee2Mqtt/Zigbee2Mqtt.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from core.base.model.Module import Module
 from core.commons import commons
-from core.dialog.model.DialogSession import DialogSession
 
 
 class Zigbee2Mqtt(Module):

--- a/PublishedModules/glueckself/MpdClient/MpdClient.install
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.install
@@ -1,10 +1,10 @@
 {
 	"name": "MpdClient",
-	"version": 0.11,
+	"version": 0.12,
 	"author": "glueckself",
 	"maintainers": ["maxbachmann"],
 	"desc": "Control an MPD server",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": ["python-mpd2"],
 	"conditions": {

--- a/PublishedModules/glueckself/MpdClient/MpdClient.py
+++ b/PublishedModules/glueckself/MpdClient/MpdClient.py
@@ -23,14 +23,16 @@ class MpdClient(Module):
 	_INTENT_PREV = Intent('mpdPrev')
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_PLAY,
-			self._INTENT_STOP,
-			self._INTENT_NEXT,
-			self._INTENT_PREV
-		]
+		self._INTENTS = {
+			self._INTENT_PLAY: self.playIntent,
+			self._INTENT_STOP: self.stopIntent,
+			self._INTENT_NEXT: self.nextIntent,
+			self._INTENT_PREV: self.prevIntent
+		}
+		#TODO volume, playlists, ...
+		#TODO pause music if alice starts a dialogue
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 		self._host = self.getConfig('mpdHost')
 		self._port = self.getConfig('mpdPort')
@@ -75,56 +77,37 @@ class MpdClient(Module):
 
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
-
 		if not self._mpdConnected:
 			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('notConnected'))
 			return True
-
-		sessionId = session.sessionId
-
-		if intent == self._INTENT_PLAY:
-			self.playIntent(sessionId)
-		elif intent == self._INTENT_STOP:
-			self.stopIntent(sessionId)
-		elif intent == self._INTENT_NEXT:
-			self.nextIntent(sessionId)
-		elif intent == self._INTENT_PREV:
-			self.prevIntent(sessionId)
-		else:
-			return False
-		return True
-		#TODO volume, playlists, ...
-		#TODO pause music if alice starts a dialogue
+		super().onMessage(intent=intent, session=session)
 
 
-	def playIntent(self, sessionId: str):
+	def playIntent(self, intent: str, session: DialogSession):
 		if self._playbackStatus:
-			self.endDialog(sessionId=sessionId, text=self.randomTalk('alreadyPlaying'))
+			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('alreadyPlaying'))
 		else:
 			self._mpd.play()
-			self.endDialog(sessionId=sessionId)
+			self.endDialog(sessionId=session.sessionId)
 	
 
-	def stopIntent(self, sessionId: str):
+	def stopIntent(self, intent: str, session: DialogSession):
 		# note that _playbackStatus can also be None when disconnected.
 		# while it shouldn't reach this line in that case, better to be on the safe side
 		if not self._playbackStatus:
-			self.endDialog(sessionId=sessionId, text=self.randomTalk('alreadyStopped'))
+			self.endDialog(sessionId=session.sessionId, text=self.randomTalk('alreadyStopped'))
 		else:
 			self._mpd.stop()
-			self.endDialog(sessionId=sessionId)
+			self.endDialog(sessionId=session.sessionId)
 	
 
-	def nextIntent(self, sessionId: str):
+	def nextIntent(self, intent: str, session: DialogSession):
 		# TODO maybe say the title here if not playing
 		self._mpd.next()
-		self.endDialog(sessionId=sessionId)
+		self.endDialog(sessionId=session.sessionId)
 	
 
-	def prevIntent(self, sessionId: str):
+	def prevIntent(self, intent: str, session: DialogSession):
 		# TODO maybe say the title here if not playing
 		self._mpd.previous()
-		self.endDialog(sessionId=sessionId)
-
+		self.endDialog(sessionId=session.sessionId)

--- a/PublishedModules/glueckself/MpdClient/README.md
+++ b/PublishedModules/glueckself/MpdClient/README.md
@@ -11,10 +11,10 @@ wget http://modules.projectalice.ch/MpdClient -O ~/ProjectAlice/system/moduleIns
 ### Description
 Control an MPD server
 
-- Version: 0.11
+- Version: 0.12
 - Author: glueckself
 - Maintainers: maxbachmann
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - de

--- a/PublishedModules/maxbachmann/RockPaperScissors/README.md
+++ b/PublishedModules/maxbachmann/RockPaperScissors/README.md
@@ -15,10 +15,10 @@ wget http://modules.projectalice.ch/RockPaperScissors -O ~/ProjectAlice/system/m
 ### Description
 Play rock paper scissors
 
-- Version: 0.2
+- Version: 0.11
 - Author: maxbachmann
 - Maintainers: Jierka, Psycho
-- Alice minimum version: 0.10
+- Alice minimum version: 0.12
 - Conditions:
   - en
   - de

--- a/PublishedModules/maxbachmann/RockPaperScissors/RockPaperScissors.install
+++ b/PublishedModules/maxbachmann/RockPaperScissors/RockPaperScissors.install
@@ -1,10 +1,10 @@
 {
 	"name": "RockPaperScissors",
-	"version": 0.1,
+	"version": 0.11,
 	"author": "maxbachmann",
 	"maintainers": ["Jierka", "Psycho"],
 	"desc": "Play rock paper scissors",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [],
 	"conditions": {

--- a/PublishedModules/maxbachmann/RockPaperScissors/RockPaperScissors.py
+++ b/PublishedModules/maxbachmann/RockPaperScissors/RockPaperScissors.py
@@ -12,18 +12,13 @@ class RockPaperScissors(Module):
 	_INTENT_ROCK_PAPER_SCISSORS = Intent('RockPaperScissors')
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_ROCK_PAPER_SCISSORS
-		]
+		self._INTENTS = {
+			self._INTENT_ROCK_PAPER_SCISSORS: self.rockPaperScissorsIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
 
-		if intent == self._INTENT_ROCK_PAPER_SCISSORS:
-			randomItem = self.randomTalk(text='RockPaperScissors')
-			self.endDialog(session.sessionId, self.randomTalk(text='answer', replace=[randomItem]))
-
-		return True
+	def rockPaperScissorsIntent(self, intent: str, session: DialogSession):
+		randomItem = self.randomTalk(text='RockPaperScissors')
+		self.endDialog(session.sessionId, self.randomTalk(text='answer', replace=[randomItem]))

--- a/PublishedModules/maxbachmann/Speedtest/Speedtest.install
+++ b/PublishedModules/maxbachmann/Speedtest/Speedtest.install
@@ -4,7 +4,7 @@
 	"author": "maxbachmann",
 	"maintainers": ["Psychokiller1888"],
 	"desc": "run internet speed test",
-	"aliceMinVersion": 0.11,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": ["speedtest-cli"],
 	"conditions": {

--- a/PublishedModules/maxbachmann/Speedtest/Speedtest.py
+++ b/PublishedModules/maxbachmann/Speedtest/Speedtest.py
@@ -24,7 +24,7 @@ class Speedtest(Module):
 	@online
 	def runSpeedtest(self, intent: str, session: DialogSession) -> str:
 		self.ThreadManager.doLater(interval=0, func=self.executeSpeedtest)
-		self._logger.info('[{}] Starting Speedtest'.format(self.name))
+		self._logger.info(f'[{self.name}] Starting Speedtest')
 		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('running'))
 
 
@@ -40,8 +40,8 @@ class Speedtest(Module):
 			result = speed.results.dict()
 			downspeed = '{:.2f}'.format(result['download']/1000000)
 			upspeed = '{:.2f}'.format(result['upload']/1000000)
-			self._logger.info('[{}] Download speed: {} Mbps, Upload speed: {} Mbps'.format(self.name, downspeed, upspeed))
+			self._logger.info(f'[{self.name}] Download speed: {downspeed} Mbps, Upload speed: {upspeed} Mbps')
 			self.say(text=self.randomTalk(text='result', replace=[downspeed, upspeed]))
 		except Exception as e:
 			self.say(self.randomTalk(text='failed'))
-			self._logger.warning('[{}] Speedtest failed with: {}'.format(self.name, e))
+			self._logger.warning(f'[{self.name}] Speedtest failed with: {e}')

--- a/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.install
+++ b/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.install
@@ -1,12 +1,13 @@
 {
 	"name": "LocalButtonPress",
-	"version": 1.5,
+	"version": 1.6,
 	"author": "mjlill",
 	"maintainers": [
-		"Psycho"
+		"Psycho",
+		"maxbachmann"
 	],
 	"desc": "Press an imaginary button on or off",
-	"aliceMinVersion": 0.10,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": [
 		"RPI.GPIO"

--- a/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.py
+++ b/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.py
@@ -16,12 +16,12 @@ class LocalButtonPress(Module):
 
 
 	def __init__(self):
-		self._SUPPORTED_INTENTS = [
-			self._INTENT_BUTTON_ON,
-			self._INTENT_BUTTON_OFF
-		]
+		self._INTENTS = {
+			self._INTENT_BUTTON_ON: self.buttonOnIntent,
+			self._INTENT_BUTTON_OFF: self.buttonOffIntent
+		}
 
-		super().__init__(self._SUPPORTED_INTENTS)
+		super().__init__(self._INTENTS)
 
 		self._gpioPin = self.getConfig('gpioPin')
 
@@ -30,17 +30,12 @@ class LocalButtonPress(Module):
 		GPIO.setup(self._gpioPin, GPIO.OUT)
 		GPIO.output(self._gpioPin, GPIO.LOW)
 
+	
+	def buttonOnIntent(self, intent: str, session: DialogSession):
+		GPIO.output(self._gpioPin, GPIO.HIGH)
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('DoButtonOn'))
 
-	def onMessage(self, intent: str, session: DialogSession) -> bool:
-		if not self.filterIntent(intent, session):
-			return False
 
-		if intent == self._INTENT_BUTTON_ON:
-			GPIO.output(self._gpioPin, GPIO.HIGH)
-			self.endDialog(session.sessionId, self.TalkManager.randomTalk('DoButtonOn'))
-
-		elif intent == self._INTENT_BUTTON_OFF:
-			GPIO.output(self._gpioPin, GPIO.LOW)
-			self.endDialog(session.sessionId, self.TalkManager.randomTalk('DoButtonOff'))
-
-		return True
+	def buttonOffIntent(self, intent: str, session: DialogSession):
+		GPIO.output(self._gpioPin, GPIO.LOW)
+		self.endDialog(session.sessionId, self.TalkManager.randomTalk('DoButtonOff'))

--- a/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.py
+++ b/PublishedModules/mjlill/LocalButtonPress/LocalButtonPress.py
@@ -30,7 +30,7 @@ class LocalButtonPress(Module):
 		GPIO.setup(self._gpioPin, GPIO.OUT)
 		GPIO.output(self._gpioPin, GPIO.LOW)
 
-	
+
 	def buttonOnIntent(self, intent: str, session: DialogSession):
 		GPIO.output(self._gpioPin, GPIO.HIGH)
 		self.endDialog(session.sessionId, self.TalkManager.randomTalk('DoButtonOn'))

--- a/PublishedModules/mjlill/LocalButtonPress/README.md
+++ b/PublishedModules/mjlill/LocalButtonPress/README.md
@@ -21,10 +21,11 @@ Press an imaginary button on or off
  Edit the python script to assign a different gpio pin
 
 
-- Version: 1.5
+- Version: 1.6
 - Author: mjlill
 - Maintainers:
   - Psycho
+  - maxbachmann
 - Alice minimum version: 0.10
 - Conditions:
   - en

--- a/PublishedModules/philipp2310/BringShoppingList/BringShoppingList.install
+++ b/PublishedModules/philipp2310/BringShoppingList/BringShoppingList.install
@@ -1,10 +1,10 @@
 {
 	"name": "BringShoppingList",
-	"version": 1.01,
+	"version": 1.02,
 	"author": "philipp2310",
-	"maintainers": [""],
+	"maintainers": ["maxbachmann"],
 	"desc": "Maintain your Bring! Shopping list",
-	"aliceMinVersion": 0.1,
+	"aliceMinVersion": 0.12,
 	"systemRequirements": [],
 	"pipRequirements": ["BringApi"],
 	"conditions": {

--- a/PublishedModules/philipp2310/BringShoppingList/BringShoppingList.py
+++ b/PublishedModules/philipp2310/BringShoppingList/BringShoppingList.py
@@ -44,8 +44,6 @@ class BringShoppingList(Module):
 
 	def onMessage(self, intent: str, session: DialogSession) -> bool:
 		"""handle all incoming messages"""
-		if not self.filterIntent(intent, session):
-			return False
 
 		if intent == self._INTENT_ADD_ITEM or (intent in {self._INTENT_ANSWER_SHOP, self._INTENT_SPELL_WORD} and session.previousIntent == self._INTENT_ADD_ITEM):
 			#Add item to list

--- a/PublishedModules/philipp2310/BringShoppingList/README.md
+++ b/PublishedModules/philipp2310/BringShoppingList/README.md
@@ -15,9 +15,9 @@ alice module:install philipp2310/BringShoppingList
 ### Description
 View and edit your Bring! Shopping list
 
-- Version: 1.01
+- Version: 1.02
 - Author: philipp2310
-- Maintainers: philipp2310
+- Maintainers: maxbachmann
 - Alice minimum version: N/A
 - Conditions:
   - en


### PR DESCRIPTION
I rewrote all modules based on changes in alpha2:
1) removed
```
if not self.filterIntent(intent, session):	
			return False
```
since it is done by alice already (did overwrite the filterIntent in the Tasmota module because it wants to accept all intents that start with 'projectalice/devices/tasmota/', and this would not work with alpha2)

2) replaced .format by f-strings when I came across them
3) when easily possible made use of the newly introduces intent:function mapping to decrease the complexity of the modules
