### PR TITLE
More natural grammar for en-US locale

### DIFF
--- a/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
+++ b/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
@@ -17,14 +17,14 @@ class DateDayTimeYear(Module):
 		if self.LanguageManager.activeLanguage == 'en':
 			if minutes <= 30:
 				if hours == 12:
-					hours = 'midday'
+					hours = 'noon'
 				elif hours == 0:
 					hours = 'midnight'
 				else:
 					hours = hours % 12
 			else:
 				if hours + 1 == 12:
-					hours = 'midday'
+					hours = 'noon'
 				elif hours + 1 == 24:
 					hours = 'midnight'
 				else:
@@ -47,7 +47,10 @@ class DateDayTimeYear(Module):
 				else:
 					answer = f'{minutes} past {hours}'
 			else:
-				answer = f"{hours} o'clock"
+				if hours == 'midnight' or hours == 'noon':
+					answer = answer = f" It is ",  {hours}"
+				else:
+					answer = f"{hours} o'clock"
 
 		elif self.LanguageManager.activeLanguage == 'fr':
 			if minutes <= 30:

--- a/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
+++ b/PublishedModules/Psychokiller1888/DateDayTimeYear/DateDayTimeYear.py
@@ -13,22 +13,15 @@ class DateDayTimeYear(Module):
 	def timeIntent(self, session: DialogSession, **_kwargs):
 		minutes = datetime.now().minute
 		hours = datetime.now().hour
+		hours24 = datetime.now().hour
 
 		if self.LanguageManager.activeLanguage == 'en':
-			if minutes <= 30:
-				if hours == 12:
-					hours = 'noon'
-				elif hours == 0:
-					hours = 'midnight'
-				else:
-					hours = hours % 12
+			if hours == 12:
+				hours = 'noon'
+			elif hours == 0:
+				hours = 'midnight'
 			else:
-				if hours + 1 == 12:
-					hours = 'noon'
-				elif hours + 1 == 24:
-					hours = 'midnight'
-				else:
-					hours = (hours % 12) + 1
+				hours = hours % 12
 
 			if minutes > 0:
 				if minutes == 15:
@@ -36,19 +29,22 @@ class DateDayTimeYear(Module):
 				elif minutes == 30:
 					answer = f'half past {hours}'
 				elif minutes == 45:
-					answer = f'quarter to {hours}'
-				elif minutes > 30:
-					answer = f'{60 - minutes} to {hours}'
+					if hours24 == 23:
+						answer = f'quarter to midnight'
+					elif hours24 == 11:
+						answer = f'quarter to noon'
+					else:
+						answer = f'quarter to {(hours24 % 12) + 1}'
 				elif 0 < minutes < 10:
 					if isinstance(hours, int):
-						answer = f'{hours} oh {minutes}'
+						answer = f'{hours} o {minutes}'
 					else:
 						answer = f'{minutes} past {hours}'
 				else:
-					answer = f'{minutes} past {hours}'
+					answer = f'{hours} {minutes}'
 			else:
 				if hours == 'midnight' or hours == 'noon':
-					answer = answer = f" It is ",  {hours}"
+					answer = answer = f" It is {hours}"
 				else:
 					answer = f"{hours} o'clock"
 


### PR DESCRIPTION
1. Cleaned up 'oh' to 'o' during statements like "9:03" e.g. nine O three. Alice was saying almost like a 'uhh' instead of 'oh'. Just putting letter 'o' fixes this.
2. Changed 'midday' to 'noon'
3. Updated and covered edge cases around noon and midnight regarding 45-past X. 

Test Cases
- hours = 0, minutes = 0
    result: it is midnight
- hours = 12, minutes = 0 PASSED
    result: it is noon
- hours = 9, minutes = 0 PASSED
    result: nine o'clock
- hours = 9, minutes = 10 PASSED
    result: nine ten
- hours = 9, minutes = 15 PASSED
    result: quarter past nine
- hours = 9, minutes = 30 PASSED
    result: half past nine
- hours = 9, minutes = 45 PASSED
    result: quarter to ten
- hours = 11, minutes = 45 (am) PASSED
    result: quarter to noon
- hours = 23, minutes = 45 (pm) PASSED
    result: quarter to midnight
- hours = 0, minutes = 45 (am) PASSED
    result: quarter to one
- hours = 12, minutes = 45 (pm) PASSED
    result: quarter to one
- hours = 11, minutes = 30 (am) PASSED
    result: half past eleven
- hours = 23, minutes = 30 (pm) PASSED
    result: half past eleven
- hours = 0, minutes = 30 (am) PASSED
    result: half past midnight
- hours = 12, minutes = 30 (pm) PASSED
    result: half past noon
- hours = 9, minutes = 59 PASSED
    result: nine fifty nine
