### PR TITLE
online contextmanager

### DIFF
--- a/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.py
+++ b/PublishedModules/Psychokiller1888/Wikipedia/Wikipedia.py
@@ -55,8 +55,8 @@ class Wikipedia(Module):
 			self._whatToSearch(session, 'noMatch')
 		except Exception as e:
 			self.logWarning(msg=e, printStack=True)
-
-		if not result:
-			self._whatToSearch(session, 'noMatch')
 		else:
-			self.endDialog(sessionId=session.sessionId, text=result)
+			if not result:
+				self._whatToSearch(session, 'noMatch')
+			else:
+				self.endDialog(sessionId=session.sessionId, text=result)


### PR DESCRIPTION
Right now when using the Online decorator it is required to use the AnyExcept Decorators aswell, since it first needs to catch the offline state and then if it is still online has to reraise, which then afterwards needs to be handled. However e.g. here in the wikipedia module this can quite a mess with a ton of decorators.

I think using this simple contextManager:
```python
@contextmanager
def Online():
	internetManager = SuperManager.getInstance().internetManager
	if internetManager.online:
		try:
			yield
		except:
			if internetManager.checkOnlineState():
				raise
	raise OfflineError
```
makes exception handling more readable and cleans up this decorator mess.
@Psychokiller1888 what do you think about this?